### PR TITLE
suppress warnings when finding pcl

### DIFF
--- a/kimera_pgmo/CMakeLists.txt
+++ b/kimera_pgmo/CMakeLists.txt
@@ -14,9 +14,20 @@ find_package(config_utilities REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(GTSAM REQUIRED)
 find_package(kimera_rpgo REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common geometry kdtree octree)
 find_package(pose_graph_tools REQUIRED)
 find_package(spatial_hash REQUIRED)
+
+set(CLEAR_WARNING_SUPPRESSION OFF)
+if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+  set(CLEAR_WARNING_SUPPRESSION ON)
+  set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
+endif()
+
+find_package(PCL REQUIRED COMPONENTS common geometry kdtree octree)
+
+if (CLEAR_WARNING_SUPPRESSION)
+  unset(CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+endif()
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/kimera_pgmo/cmake/kimera_pgmoConfig.cmake.in
+++ b/kimera_pgmo/cmake/kimera_pgmoConfig.cmake.in
@@ -9,7 +9,18 @@ find_dependency(GTSAM REQUIRED)
 find_dependency(kimera_rpgo REQUIRED)
 find_dependency(pose_graph_tools REQUIRED)
 find_dependency(spatial_hash REQUIRED)
+
+set(CLEAR_WARNING_SUPPRESSION OFF)
+if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+  set(CLEAR_WARNING_SUPPRESSION ON)
+  set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
+endif()
+
 find_dependency(PCL REQUIRED COMPATIBILITY common geometry kdtree octree)
+
+if (CLEAR_WARNING_SUPPRESSION)
+  unset(CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+endif()
 
 if(NOT TARGET kimera_pgmo::kimera_pgmo)
   include("${kimera_pgmo_CMAKE_DIR}/kimera_pgmoTargets.cmake")


### PR DESCRIPTION
@yunzc Gets rid of the annoying cmake warning when PCL tries to find FLANN (both for this and downstream packages)