### PR TITLE
Feature/self contained delta

### DIFF
--- a/kimera_pgmo/include/kimera_pgmo/compression/delta_compression.h
+++ b/kimera_pgmo/include/kimera_pgmo/compression/delta_compression.h
@@ -89,14 +89,6 @@ class DeltaCompression {
   void archiveBlocksByTime(uint64_t earliest_time_ns);
 
   /**
-   * @brief Archive blocks in the provided index list
-   * @param blocks Block indices to archive
-   *
-   * @note Deprecated as spatial grid should be maintained internal to compression
-   */
-  [[deprecated]] void clearArchivedBlocks(const spatial_hash::BlockIndices& blocks);
-
-  /**
    * @brief Archive blocks in the underlying spatial grid
    * @param should_archive Filter function that returns true if a block should be
    * archived
@@ -124,9 +116,7 @@ class DeltaCompression {
 
   void updateRemapping(MeshInterface& mesh, uint64_t timestamp_ns);
 
-  bool canBeArchived(const Face& face, size_t archive_threshold) const;
-
-  bool canBeArchived(const Face& face) const;
+  void addPendingVertices(MeshDelta& delta);
 
  protected:
   double resolution_;

--- a/kimera_pgmo/include/kimera_pgmo/compression/delta_compression.h
+++ b/kimera_pgmo/include/kimera_pgmo/compression/delta_compression.h
@@ -116,7 +116,7 @@ class DeltaCompression {
 
   void updateRemapping(MeshInterface& mesh, uint64_t timestamp_ns);
 
-  void addPendingVertices(MeshDelta& delta);
+  void addPendingVertices(MeshDelta& delta, size_t start_index = 0);
 
  protected:
   double resolution_;

--- a/kimera_pgmo/include/kimera_pgmo/compression/delta_compression.h
+++ b/kimera_pgmo/include/kimera_pgmo/compression/delta_compression.h
@@ -112,7 +112,9 @@ class DeltaCompression {
 
   void updateAndAddArchivedFaces();
 
-  void archiveBlockFaces(const BlockInfo& block_info, RedunancyChecker& checker);
+  void archiveBlockFaces(const BlockInfo& block_info,
+                         RedunancyChecker& checker,
+                         std::vector<Face>& pending_faces);
 
   void updateRemapping(MeshInterface& mesh, uint64_t timestamp_ns);
 

--- a/kimera_pgmo/include/kimera_pgmo/compression/delta_compression.h
+++ b/kimera_pgmo/include/kimera_pgmo/compression/delta_compression.h
@@ -139,6 +139,7 @@ class DeltaCompression {
   BlockInfoMap block_info_map_;
   VoxelInfoMap vertices_map_;
 
+  std::vector<VertexInfo> archived_vertices_;
   std::vector<Face> archived_faces_;
 
   uint16_t sequence_number_;

--- a/kimera_pgmo/include/kimera_pgmo/mesh_delta.h
+++ b/kimera_pgmo/include/kimera_pgmo/mesh_delta.h
@@ -84,7 +84,8 @@ class MeshDelta {
                   std::vector<uint32_t>* semantics = nullptr,
                   const Eigen::Isometry3f* transform = nullptr) const;
 
-  void offsetVertices(size_t new_archive_size);
+  void setOffset(std::optional<size_t> vertex_start = std::nullopt,
+                 std::optional<size_t> face_start = std::nullopt);
 
   size_t addVertex(Timestamp timestamp_ns,
                    const pcl::PointXYZRGBA& point,
@@ -136,6 +137,8 @@ class MeshDelta {
   std::set<size_t> new_indices;
 
  protected:
+  size_t remapIndex(size_t prev) const;
+
   size_t num_archived_vertices_ = 0;
 };
 
@@ -172,6 +175,15 @@ void MeshDelta::updateFaces(Faces& faces) const {
   const size_t total_faces =
       face_start + face_archive_updates.size() + face_updates.size();
   traits::resize_faces(faces, total_faces);
+
+  // TODO(nathan) there is a more elegant way to do this
+  for (size_t i = 0; i < getTotalArchivedFaces(); ++i) {
+    auto face = traits::get_face(faces, i);
+    face[0] = remapIndex(face[0]);
+    face[1] = remapIndex(face[1]);
+    face[2] = remapIndex(face[2]);
+    traits::set_face(faces, i, face);
+  }
 
   size_t face_idx = face_start;
   for (const auto& face : face_archive_updates) {

--- a/kimera_pgmo/include/kimera_pgmo/mesh_delta.h
+++ b/kimera_pgmo/include/kimera_pgmo/mesh_delta.h
@@ -84,6 +84,8 @@ class MeshDelta {
                   std::vector<uint32_t>* semantics = nullptr,
                   const Eigen::Isometry3f* transform = nullptr) const;
 
+  void offsetVertices(size_t new_archive_size);
+
   size_t addVertex(Timestamp timestamp_ns,
                    const pcl::PointXYZRGBA& point,
                    std::optional<uint32_t> semantics = std::nullopt,

--- a/kimera_pgmo/src/compression/delta_compression.cpp
+++ b/kimera_pgmo/src/compression/delta_compression.cpp
@@ -19,6 +19,12 @@ using spatial_hash::BlockIndices;
 
 namespace {
 
+inline size_t addPointToDelta(MeshDelta& delta,
+                              const VertexInfo& info,
+                              bool should_archive = false) {
+  return delta.addVertex(info.timestamp_ns, info.point, info.label, should_archive);
+}
+
 inline size_t getRemappedIndex(const std::map<size_t, size_t>& remapping,
                                size_t original) {
   const auto iter = remapping.find(original);
@@ -142,17 +148,16 @@ void DeltaCompression::removeBlockObservations(const LongIndexSet& to_remove) {
     }
 
     // we can't observe a vertex and then need to archive it in the same pass, so
-    // info.mesh_index should point to the previous index
-    const size_t mesh_index =
-        delta_->addVertex(info.timestamp_ns, info.point, info.label, true);
-    delta_->prev_to_curr[info.mesh_index] = mesh_index;
+    // info.mesh_index should point to the previous index. Need to add vertex to
+    // boundary list to be processed later
+    //archived_vertices_.push_back(info);
     vertices_map_.erase(prev);
   }
 }
 
 void DeltaCompression::addActiveVertices() {
   for (auto& [vertex_idx, info] : vertices_map_) {
-    const size_t new_idx = delta_->addVertex(info.timestamp_ns, info.point, info.label);
+    const auto new_idx = addPointToDelta(*delta_, info);
     if (info.sequence_number != sequence_number_) {
       // if we haven't seen this vertex in this pass, add to prev_to_curr map
       delta_->prev_to_curr[info.mesh_index] = new_idx;
@@ -242,19 +247,24 @@ MeshDelta::Ptr DeltaCompression::update(MeshInterface& mesh,
                                         HashedIndexMapping* remapping) {
   // 1) Update happens independently of calls to archiveBlocks and archiveBlocksByTime.
   // We copy over the archive delta if it exists instead of making a new one.
+  size_t prev_num_pending = 0;
   if (archive_delta_) {
+    // we need to cache the amount of pending vertices we've already copied
+    prev_num_pending = archive_delta_->vertex_updates->size() -
+                       archive_delta_->getNumArchivedVertices();
     delta_ = archive_delta_;
     archive_delta_.reset();
   } else {
     delta_.reset(new MeshDelta(num_archived_vertices_, num_archived_faces_));
-    // this handles a corner case where archive is only called intermittently (like in
-    // the unit tests), will do nothing in practice
-    addPendingVertices(*delta_);
   }
 
   // 2) Compute the actual compression of the latest mesh, determining the remapping
   // between vertex indices in the provided mesh to vertices in the compressed mesh.
   updateRemapping(mesh, timestamp_ns);
+
+  // Applies any pending vertices that may be left over from old archival passes or from
+  // removed block observations
+  addPendingVertices(*delta_, prev_num_pending);
 
   // 3) Add all active vertices and faces to the output mesh delta. This is any
   // compressed vertex that is the result of one or more blocks that hasn't
@@ -396,8 +406,7 @@ void DeltaCompression::archiveBlocks(const BlockFilter& to_archive) {
     }
 
     // add newly archived vertex to mesh delta
-    const size_t new_index =
-        archive_delta_->addVertex(info.timestamp_ns, info.point, info.label, true);
+    const auto new_index = addPointToDelta(*archive_delta_, info, true);
     archive_delta_->prev_to_curr[info.mesh_index] = new_index;
     // "delete" vertex by swapping to end and decreasing size
     std::swap(archived_vertices_[i], archived_vertices_[boundary - 1]);
@@ -405,18 +414,17 @@ void DeltaCompression::archiveBlocks(const BlockFilter& to_archive) {
     i -= 1;
   }
 
+  // 4. Add boundary vertices to delta (allows archiving of faces pointing to pending or
+  // archived vertices)
   archived_vertices_.resize(boundary);
+  addPendingVertices(*archive_delta_);
 
-  // 4. Sweep archived faces
+  // 5. Sweep archived faces
   RedunancyChecker checker;
   for (const auto& idx : to_erase) {
     archiveBlockFaces(block_info_map_.at(idx), checker);
     block_info_map_.erase(idx);
   }
-
-  // 5. Add boundary vertices to delta (avoids accidentally archiving faces by coming
-  // after the archived face sweep)
-  addPendingVertices(*archive_delta_);
 
   SPARK_LOG(DEBUG) << "Finished archive with delta containing "
                    << archive_delta_->vertex_updates->size() << " vertice(s), "
@@ -429,24 +437,22 @@ void DeltaCompression::archiveBlocks(const BlockFilter& to_archive) {
 
 void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
                                          RedunancyChecker& checker) {
+  // We want to archive any face that points to an archived vertex or a pending vertex,
+  // so we use the total vertices in the archive delta (which contains the new archived
+  // vertices and the new pending vertices)
+  const auto archive_threshold = archive_delta_->getTotalVertices();
+
   // this remapping points from the previous active index to the current archival index
   // of all vertices archived from the block being archived. Any active vertex (or
   // previously archived vertex) will not be in the remapping
-  const auto archive_threshold = archive_delta_->getTotalArchivedVertices();
-  const auto& prev_to_curr = archive_delta_->prev_to_curr;
-
-  // for all faces in the block:
-  //   - if the face has some indices that haven't been archived yet, store for later
-  //     archival
-  //   - remap all archived vertices to their correct indices and archive the face
   const auto& indices = block_info.indices;
+  const auto& prev_to_curr = archive_delta_->prev_to_curr;
   for (size_t i = 0; i + 2 < indices.size(); i += 3) {
     Face face(indices, i);
 
-    // NOTE(nathan) prev_to_curr.count(idx) checks that the vertex was added to
+    // prev_to_curr.count(idx) checks that the vertex was added to
     // the archive delta, so this condition is saying that vertex index from the
     // previous update was not archived in this archival pass or a previous one.
-    // This techincally should be true?
     bool v1_can_archive =
         prev_to_curr.count(face.v1) || face.v1 < num_archived_vertices_;
     bool v2_can_archive =
@@ -457,20 +463,20 @@ void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
       // push any face that we can't deal with currently to be considered for archival
       // later. Crucially, we don't remap any face indices here as we can't
       // distinguish whether an index was remapped here or not
-      archived_faces_.push_back(face);
+      //archived_faces_.push_back(face);
       continue;
     }
 
     // remap face to respect newly archived vertices
-    face.v1 = getRemappedIndex(prev_to_curr, face.v1);
-    face.v2 = getRemappedIndex(prev_to_curr, face.v2);
-    face.v3 = getRemappedIndex(prev_to_curr, face.v3);
+    face.v1 = getRemappedIndex(prev_to_curr, face.v1, num_archived_vertices_);
+    face.v2 = getRemappedIndex(prev_to_curr, face.v2, num_archived_vertices_);
+    face.v3 = getRemappedIndex(prev_to_curr, face.v3, num_archived_vertices_);
     if (!face.valid()) {
       continue;
     }
 
     if (!canBeArchived(face, archive_threshold)) {
-      archived_faces_.push_back(face);
+      //archived_faces_.push_back(face);
       continue;
     }
 
@@ -520,11 +526,12 @@ void DeltaCompression::updateAndAddArchivedFaces() {
   }
 }
 
-void DeltaCompression::addPendingVertices(MeshDelta& delta) {
+void DeltaCompression::addPendingVertices(MeshDelta& delta, size_t start_index) {
   // note that unlike the archived vertices, the mesh index of pending boundary vertices
   // changes every pass until they are actually fully archived
-  for (auto& info : archived_vertices_) {
-    const size_t new_index = delta.addVertex(info.timestamp_ns, info.point, info.label);
+  for (size_t i = start_index; i < archived_vertices_.size(); ++i) {
+    auto& info = archived_vertices_[i];
+    const auto new_index = addPointToDelta(delta, info);
     delta.prev_to_curr[info.mesh_index] = new_index;
     info.mesh_index = new_index;
   }

--- a/kimera_pgmo/src/compression/delta_compression.cpp
+++ b/kimera_pgmo/src/compression/delta_compression.cpp
@@ -42,7 +42,7 @@ inline size_t getRemappedIndex(const std::map<size_t, size_t>& remapping,
   return getRemappedIndex(remapping, original);
 }
 
-inline bool canBeArchived(const Face& face, size_t archive_threshold) {
+inline bool allVerticesBelow(const Face& face, size_t archive_threshold) {
   return face.v1 < archive_threshold && face.v2 < archive_threshold &&
          face.v3 < archive_threshold;
 }
@@ -421,11 +421,16 @@ void DeltaCompression::archiveBlocks(const BlockFilter& to_archive) {
 
   // 5. Sweep archived faces
   RedunancyChecker checker;
+  std::vector<Face> pending_faces;
   for (const auto& idx : to_erase) {
-    archiveBlockFaces(block_info_map_.at(idx), checker);
+    archiveBlockFaces(block_info_map_.at(idx), checker, pending_faces);
     block_info_map_.erase(idx);
   }
 
+  archive_delta_->face_archive_updates.insert(
+      archive_delta_->face_archive_updates.end(),
+      pending_faces.begin(),
+      pending_faces.end());
   SPARK_LOG(DEBUG) << "Finished archive with delta containing "
                    << archive_delta_->vertex_updates->size() << " vertice(s), "
                    << archive_delta_->face_updates.size() << " face(s), and "
@@ -436,11 +441,13 @@ void DeltaCompression::archiveBlocks(const BlockFilter& to_archive) {
 }
 
 void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
-                                         RedunancyChecker& checker) {
+                                         RedunancyChecker& checker,
+                                         std::vector<Face>& pending_faces) {
   // We want to archive any face that points to an archived vertex or a pending vertex,
   // so we use the total vertices in the archive delta (which contains the new archived
   // vertices and the new pending vertices)
   const auto archive_threshold = archive_delta_->getTotalVertices();
+  const auto pending_threshold = archive_delta_->getTotalArchivedVertices();
 
   // this remapping points from the previous active index to the current archival index
   // of all vertices archived from the block being archived. Any active vertex (or
@@ -475,7 +482,7 @@ void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
       continue;
     }
 
-    if (!canBeArchived(face, archive_threshold)) {
+    if (!allVerticesBelow(face, archive_threshold)) {
       archived_faces_.push_back(face);
       continue;
     }
@@ -485,7 +492,12 @@ void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
     }
 
     checker.add(face);
-    archive_delta_->addFace(face, true);
+    const auto fully_archived = allVerticesBelow(face, pending_threshold);
+    if (fully_archived) {
+      archive_delta_->addFace(face, true);
+    } else {
+      pending_faces.push_back(face);
+    }
   }
 }
 
@@ -515,7 +527,7 @@ void DeltaCompression::updateAndAddArchivedFaces() {
       continue;
     }
 
-    const bool can_archive = canBeArchived(face, archive_threshold);
+    const bool can_archive = allVerticesBelow(face, archive_threshold);
     checker.add(face);
     delta_->addFace(face, can_archive);
     if (can_archive) {

--- a/kimera_pgmo/src/compression/delta_compression.cpp
+++ b/kimera_pgmo/src/compression/delta_compression.cpp
@@ -10,27 +10,54 @@
 
 #include "kimera_pgmo/compression/redundancy_checker.h"
 #include "kimera_pgmo/utils/common_functions.h"
+#include "kimera_pgmo/utils/logging.h"
 
 namespace kimera_pgmo {
 
 using spatial_hash::BlockIndex;
 using spatial_hash::BlockIndices;
 
-size_t getRemappedIndex(const std::map<size_t, size_t>& remapping, size_t original) {
+namespace {
+
+inline size_t getRemappedIndex(const std::map<size_t, size_t>& remapping,
+                               size_t original) {
   const auto iter = remapping.find(original);
   // TODO(Yun): technically should always have key in remapping
   return iter == remapping.end() ? original : iter->second;
 }
 
-size_t getRemappedIndex(const std::map<size_t, size_t>& remapping,
-                        size_t original,
-                        size_t threshold) {
+inline size_t getRemappedIndex(const std::map<size_t, size_t>& remapping,
+                               size_t original,
+                               size_t threshold) {
   if (original < threshold) {
     return original;
   }
 
   return getRemappedIndex(remapping, original);
 }
+
+inline bool canBeArchived(const Face& face, size_t archive_threshold) {
+  return face.v1 < archive_threshold && face.v2 < archive_threshold &&
+         face.v3 < archive_threshold;
+}
+
+inline void markBoundaryVertices(const Face& face,
+                                 const size_t num_archived,
+                                 std::unordered_set<size_t>& pending) {
+  if ((pending.count(face.v1) || face.v1 < num_archived) &&
+      (pending.count(face.v2) || face.v2 < num_archived) &&
+      (pending.count(face.v3) || face.v3 < num_archived)) {
+    // face points to vertices that are either archived or not archived
+    return;
+  }
+
+  // at least one vertex points at an active vertex, don't archive anything yet
+  pending.erase(face.v1);
+  pending.erase(face.v2);
+  pending.erase(face.v3);
+}
+
+}  // namespace
 
 void VertexInfo::addObservation() const { ++active_refs; }
 
@@ -165,13 +192,12 @@ void DeltaCompression::addActiveFaces(uint64_t timestamp_ns,
   const auto& prev_to_curr = delta_->prev_to_curr;
   // note that we only need to check for duplicates per each "type" of face
   RedunancyChecker checker;
-  for (auto& id_info_pair : block_info_map_) {
-    auto& block_info = id_info_pair.second;
+  for (auto& [idx, block_info] : block_info_map_) {
     const bool was_updated = block_info.sequence_number == sequence_number_;
 
     IndexMapping* block_remap = nullptr;
     if (remapping && was_updated) {
-      block_remap = &(remapping->insert({id_info_pair.first, {}}).first->second);
+      block_remap = &(remapping->insert({idx, {}}).first->second);
     }
 
     auto& indices = block_info.indices;
@@ -221,6 +247,9 @@ MeshDelta::Ptr DeltaCompression::update(MeshInterface& mesh,
     archive_delta_.reset();
   } else {
     delta_.reset(new MeshDelta(num_archived_vertices_, num_archived_faces_));
+    // this handles a corner case where archive is only called intermittently (like in
+    // the unit tests), will do nothing in practice
+    addPendingVertices(*delta_);
   }
 
   // 2) Compute the actual compression of the latest mesh, determining the remapping
@@ -312,58 +341,26 @@ void DeltaCompression::archiveBlocksByTime(uint64_t earliest_time_ns) {
   });
 }
 
-void DeltaCompression::clearArchivedBlocks(const BlockIndices& blocks) {
-  spatial_hash::IndexSet to_archive(blocks.begin(), blocks.end());
-  archiveBlocks(
-      [&to_archive](const auto& idx, const auto&) { return to_archive.count(idx); });
-}
-
 void DeltaCompression::archiveBlocks(const BlockFilter& to_archive) {
-  // only reset archive delta if necessary (to allow for multiple archive calls)
+  // 0. Only reset archive delta if necessary (to allow for multiple archive calls)
   if (!archive_delta_) {
     archive_delta_.reset(new MeshDelta(num_archived_vertices_, num_archived_faces_));
   }
 
-  std::unordered_set<size_t> pending_archive;
-  for (const auto& [idx, block_info] : block_info_map_) {
-    if (!to_archive(idx, block_info)) {
-      continue;
-    }
-
-    // for every block we want to archive:
-    //   - update ref counts for any vertices the block contains
-    //   - any voxel/vertex that only has archived blocks pointing to it should get
-    //     archived by being added to the archive_delta_ (to be used as a starting point
-    //     next update call)
-    to_erase.push_back(idx);
-
-    for (const auto& voxel : block_info.vertices) {
-      auto& info = vertices_map_[voxel];
-      info.archiveObservation();
-      if (!info.shouldArchive()) {
-        continue;
-      }
-
-      const size_t new_index =
-          archive_delta_->addVertex(info.timestamp_ns, info.point, info.label, true);
-      archive_delta_->prev_to_curr[info.mesh_index] = new_index;
-      vertices_map_.erase(voxel);
-    }
+  // 1(a). Populate current archived indices
+  std::unordered_set<size_t> pending_vertices;
+  for (const auto& pending : archived_vertices_) {
+    pending_vertices.insert(pending.mesh_index);
   }
 
+  // 1(b). Add newly archived vertices to archival candidates (and mark archived blocks)
   spatial_hash::BlockIndices to_erase;
   for (const auto& [idx, block_info] : block_info_map_) {
     if (!to_archive(idx, block_info)) {
       continue;
     }
 
-    // for every block we want to archive:
-    //   - update ref counts for any vertices the block contains
-    //   - any voxel/vertex that only has archived blocks pointing to it should get
-    //     archived by being added to the archive_delta_ (to be used as a starting point
-    //     next update call)
     to_erase.push_back(idx);
-
     for (const auto& voxel : block_info.vertices) {
       auto& info = vertices_map_[voxel];
       info.archiveObservation();
@@ -371,18 +368,63 @@ void DeltaCompression::archiveBlocks(const BlockFilter& to_archive) {
         continue;
       }
 
-      const size_t new_index =
-          archive_delta_->addVertex(info.timestamp_ns, info.point, info.label, true);
-      archive_delta_->prev_to_curr[info.mesh_index] = new_index;
+      archived_vertices_.push_back(info);
+      pending_vertices.insert(info.mesh_index);
       vertices_map_.erase(voxel);
     }
   }
 
+  // 2. Mark vertices that can be archived by checking pending faces for archive
+  for (const auto& idx : to_erase) {
+    const auto& block_info = block_info_map_[idx];
+    for (size_t i = 0; i < block_info.indices.size(); i += 3) {
+      const Face face(block_info.indices, i);
+      markBoundaryVertices(face, num_archived_vertices_, pending_vertices);
+    }
+  }
+
+  for (const auto& face : archived_faces_) {
+    markBoundaryVertices(face, num_archived_vertices_, pending_vertices);
+  }
+
+  // 3. Sweep archived vertices
+  size_t boundary = archived_vertices_.size();
+  for (size_t i = 0; i < boundary; ++i) {
+    const auto& info = archived_vertices_[i];
+    if (!pending_vertices.count(info.mesh_index)) {
+      continue;
+    }
+
+    // add newly archived vertex to mesh delta
+    const size_t new_index =
+        archive_delta_->addVertex(info.timestamp_ns, info.point, info.label, true);
+    archive_delta_->prev_to_curr[info.mesh_index] = new_index;
+    // "delete" vertex by swapping to end and decreasing size
+    std::swap(archived_vertices_[i], archived_vertices_[boundary - 1]);
+    boundary -= 1;
+    i -= 1;
+  }
+
+  archived_vertices_.resize(boundary);
+
+  // 4. Sweep archived faces
   RedunancyChecker checker;
   for (const auto& idx : to_erase) {
     archiveBlockFaces(block_info_map_.at(idx), checker);
     block_info_map_.erase(idx);
   }
+
+  // 5. Add boundary vertices to delta (avoids accidentally archiving faces by coming
+  // after the archived face sweep)
+  addPendingVertices(*archive_delta_);
+
+  SPARK_LOG(DEBUG) << "Finished archive with delta containing "
+                   << archive_delta_->vertex_updates->size() << " vertice(s), "
+                   << archive_delta_->face_updates.size() << " face(s), and "
+                   << archive_delta_->face_archive_updates.size()
+                   << " archived face(s) with "
+                   << archive_delta_->getNumArchivedVertices()
+                   << " vertice(s) being archived";
 }
 
 void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
@@ -399,7 +441,12 @@ void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
   //   - remap all archived vertices to their correct indices and archive the face
   const auto& indices = block_info.indices;
   for (size_t i = 0; i + 2 < indices.size(); i += 3) {
-    Face face(indices[i], indices[i + 1], indices[i + 2]);
+    Face face(indices, i);
+
+    // NOTE(nathan) prev_to_curr.count(idx) checks that the vertex was added to
+    // the archive delta, so this condition is saying that vertex index from the
+    // previous update was not archived in this archival pass or a previous one.
+    // This techincally should be true?
     bool v1_can_archive =
         prev_to_curr.count(face.v1) || face.v1 < num_archived_vertices_;
     bool v2_can_archive =
@@ -414,10 +461,10 @@ void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
       continue;
     }
 
+    // remap face to respect newly archived vertices
     face.v1 = getRemappedIndex(prev_to_curr, face.v1);
     face.v2 = getRemappedIndex(prev_to_curr, face.v2);
     face.v3 = getRemappedIndex(prev_to_curr, face.v3);
-
     if (!face.valid()) {
       continue;
     }
@@ -448,7 +495,6 @@ void DeltaCompression::updateAndAddArchivedFaces() {
     face.v1 = getRemappedIndex(prev_to_curr, face.v1, num_archived_vertices_);
     face.v2 = getRemappedIndex(prev_to_curr, face.v2, num_archived_vertices_);
     face.v3 = getRemappedIndex(prev_to_curr, face.v3, num_archived_vertices_);
-
     if (!face.valid()) {
       iter = archived_faces_.erase(iter);
       continue;
@@ -474,13 +520,14 @@ void DeltaCompression::updateAndAddArchivedFaces() {
   }
 }
 
-bool DeltaCompression::canBeArchived(const Face& face, size_t archive_threshold) const {
-  return face.v1 < archive_threshold && face.v2 < archive_threshold &&
-         face.v3 < archive_threshold;
-}
-
-bool DeltaCompression::canBeArchived(const Face& face) const {
-  return canBeArchived(face, num_archived_vertices_);
+void DeltaCompression::addPendingVertices(MeshDelta& delta) {
+  // note that unlike the archived vertices, the mesh index of pending boundary vertices
+  // changes every pass until they are actually fully archived
+  for (auto& info : archived_vertices_) {
+    const size_t new_index = delta.addVertex(info.timestamp_ns, info.point, info.label);
+    delta.prev_to_curr[info.mesh_index] = new_index;
+    info.mesh_index = new_index;
+  }
 }
 
 }  // namespace kimera_pgmo

--- a/kimera_pgmo/src/compression/delta_compression.cpp
+++ b/kimera_pgmo/src/compression/delta_compression.cpp
@@ -150,7 +150,7 @@ void DeltaCompression::removeBlockObservations(const LongIndexSet& to_remove) {
     // we can't observe a vertex and then need to archive it in the same pass, so
     // info.mesh_index should point to the previous index. Need to add vertex to
     // boundary list to be processed later
-    //archived_vertices_.push_back(info);
+    archived_vertices_.push_back(info);
     vertices_map_.erase(prev);
   }
 }
@@ -463,7 +463,7 @@ void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
       // push any face that we can't deal with currently to be considered for archival
       // later. Crucially, we don't remap any face indices here as we can't
       // distinguish whether an index was remapped here or not
-      //archived_faces_.push_back(face);
+      archived_faces_.push_back(face);
       continue;
     }
 
@@ -476,7 +476,7 @@ void DeltaCompression::archiveBlockFaces(const BlockInfo& block_info,
     }
 
     if (!canBeArchived(face, archive_threshold)) {
-      //archived_faces_.push_back(face);
+      archived_faces_.push_back(face);
       continue;
     }
 

--- a/kimera_pgmo/src/compression/delta_compression.cpp
+++ b/kimera_pgmo/src/compression/delta_compression.cpp
@@ -319,9 +319,36 @@ void DeltaCompression::clearArchivedBlocks(const BlockIndices& blocks) {
 }
 
 void DeltaCompression::archiveBlocks(const BlockFilter& to_archive) {
-  // only reset archive delta if necessary (to allow for multiple archive calls
+  // only reset archive delta if necessary (to allow for multiple archive calls)
   if (!archive_delta_) {
     archive_delta_.reset(new MeshDelta(num_archived_vertices_, num_archived_faces_));
+  }
+
+  std::unordered_set<size_t> pending_archive;
+  for (const auto& [idx, block_info] : block_info_map_) {
+    if (!to_archive(idx, block_info)) {
+      continue;
+    }
+
+    // for every block we want to archive:
+    //   - update ref counts for any vertices the block contains
+    //   - any voxel/vertex that only has archived blocks pointing to it should get
+    //     archived by being added to the archive_delta_ (to be used as a starting point
+    //     next update call)
+    to_erase.push_back(idx);
+
+    for (const auto& voxel : block_info.vertices) {
+      auto& info = vertices_map_[voxel];
+      info.archiveObservation();
+      if (!info.shouldArchive()) {
+        continue;
+      }
+
+      const size_t new_index =
+          archive_delta_->addVertex(info.timestamp_ns, info.point, info.label, true);
+      archive_delta_->prev_to_curr[info.mesh_index] = new_index;
+      vertices_map_.erase(voxel);
+    }
   }
 
   spatial_hash::BlockIndices to_erase;

--- a/kimera_pgmo/src/mesh_delta.cpp
+++ b/kimera_pgmo/src/mesh_delta.cpp
@@ -141,6 +141,44 @@ void MeshDelta::updateMesh(pcl::PointCloud<pcl::PointXYZRGBA>& vertices,
   updateFaces(faces);
 }
 
+void MeshDelta::offsetVertices(size_t new_archive_size) {
+  size_t offset = vertex_start - new_archive_size;
+  vertex_start = new_archive_size;
+  for (auto& face : face_updates) {
+    face.v1 -= offset;
+    face.v2 -= offset;
+    face.v3 -= offset;
+  }
+
+  for (auto& face : face_archive_updates) {
+    face.v1 -= offset;
+    face.v2 -= offset;
+    face.v3 -= offset;
+  }
+
+  for (auto& [prev, curr] : prev_to_curr) {
+    curr -= offset;
+  }
+
+  std::set<size_t> new_deleted;
+  for (const auto old : deleted_indices) {
+    new_deleted.insert(old - offset);
+  }
+  deleted_indices = new_deleted;
+
+  std::set<size_t> new_observed;
+  for (const auto old : observed_indices) {
+    new_observed.insert(old - offset);
+  }
+  observed_indices = new_observed;
+
+  std::set<size_t> new_new;
+  for (const auto old : new_indices) {
+    new_new.insert(old - offset);
+  }
+  new_indices = new_new;
+}
+
 size_t MeshDelta::addVertex(uint64_t timestamp_ns,
                             const pcl::PointXYZRGBA& point,
                             std::optional<uint32_t> semantics,

--- a/kimera_pgmo/src/mesh_delta.cpp
+++ b/kimera_pgmo/src/mesh_delta.cpp
@@ -91,17 +91,10 @@ MeshDelta::MeshDelta(size_t vertex_start, size_t face_start)
 MeshDelta::MeshDelta(const pcl::PointCloud<pcl::PointXYZRGBA>& vertices,
                      const std::vector<uint64_t>& stamps,
                      const std::vector<pcl::Vertices>& faces,
-                     std::optional<std::vector<uint32_t>> semantics) {
-  vertex_start = 0;
-  face_start = 0;
-
-  vertex_updates.reset(new pcl::PointCloud<pcl::PointXYZRGBA>(vertices));
-  stamp_updates = stamps;
-
-  if (semantics) {
-    semantic_updates = *semantics;
-  }
-
+                     std::optional<std::vector<uint32_t>> semantics)
+    : vertex_updates(new pcl::PointCloud<pcl::PointXYZRGBA>(vertices)),
+      stamp_updates(stamps),
+      semantic_updates(semantics ? *semantics : std::vector<uint32_t>{}) {
   face_updates.reserve(faces.size());
   for (const auto& face : faces) {
     Face f(face.vertices[0], face.vertices[1], face.vertices[2]);
@@ -141,9 +134,17 @@ void MeshDelta::updateMesh(pcl::PointCloud<pcl::PointXYZRGBA>& vertices,
   updateFaces(faces);
 }
 
-void MeshDelta::offsetVertices(size_t new_archive_size) {
-  size_t offset = vertex_start - new_archive_size;
-  vertex_start = new_archive_size;
+void MeshDelta::setOffset(std::optional<size_t> new_vertex_start,
+                          std::optional<size_t> new_face_start) {
+  // update face offset
+  face_start = new_face_start.value_or(face_start);
+  if (!new_vertex_start) {
+    return;
+  }
+
+  const size_t offset = vertex_start - *new_vertex_start;
+  vertex_start = *new_vertex_start;
+
   for (auto& face : face_updates) {
     face.v1 -= offset;
     face.v2 -= offset;
@@ -156,9 +157,14 @@ void MeshDelta::offsetVertices(size_t new_archive_size) {
     face.v3 -= offset;
   }
 
+  // TODO(nathan) should check this eventually, but prev points to pending or active
+  // vertices, which should all have been reindex the same way (by whatever offset has
+  // changed where the pending vertices start)
+  std::map<size_t, size_t> new_mapping;
   for (auto& [prev, curr] : prev_to_curr) {
-    curr -= offset;
+    new_mapping[prev - offset] = curr - offset;
   }
+  prev_to_curr = new_mapping;
 
   std::set<size_t> new_deleted;
   for (const auto old : deleted_indices) {
@@ -297,6 +303,15 @@ void MeshDelta::checkFaces(const std::string& name) const {
       throw std::runtime_error(ss.str());
     }
   }
+}
+
+size_t MeshDelta::remapIndex(size_t orig) const {
+  if (orig < vertex_start) {
+    return orig;
+  }
+
+  auto iter = prev_to_curr.find(orig);
+  return iter == prev_to_curr.end() ? orig : iter->second;
 }
 
 std::ostream& operator<<(std::ostream& out, const MeshDelta& delta) {

--- a/kimera_pgmo/test/test_delta_compression.cpp
+++ b/kimera_pgmo/test/test_delta_compression.cpp
@@ -407,12 +407,12 @@ CompressionTestConfiguration test_configurations[] = {
            {{0, 1, 2}, {12, 13, 14}},  // b1 archived faces
            {}}},                       // no remapping for empty input
          {{std::nullopt, 104s, {block1_v1}},
-          {{6, 2, 6},                               // b1 added again
-           {{15, 16, 17}, {21, 22, 23}},            // b1 faces
+          {{3, 1, 9},                               // b1 added again
+           {{12, 13, 14}, {15, 16, 17}, {21, 22, 23}},            // b1 faces
            {15, 16, 17, 15, 16, 17, 21, 22, 23}}},  // offset 15
          {{std::nullopt, 105s, {block1_v1}},
-          {{6, 2, 6},                               // b1 stays added
-           {{24, 25, 26}, {30, 31, 32}},            // faces indices overriden
+          {{3, 1, 9},                               // b1 stays added
+           {{12, 13, 14}, {24, 25, 26}, {30, 31, 32}},            // faces indices overriden
            {24, 25, 26, 24, 25, 26, 30, 31, 32}}},  // offset 24
      }},
     {"MultiBlockPartialUpdates",

--- a/kimera_pgmo/test/test_delta_compression.cpp
+++ b/kimera_pgmo/test/test_delta_compression.cpp
@@ -251,9 +251,9 @@ void ExpectedDelta::checkTriangles(
       }
     }
 
-    EXPECT_TRUE(found_match) << "result face "
-                             << " (r: " << rface << ", a: " << absolute_face
-                             << ", i: " << i << ") has no match in expected: "
+    EXPECT_TRUE(found_match) << "result face " << " (r: " << rface
+                             << ", a: " << absolute_face << ", i: " << i
+                             << ") has no match in expected: "
                              << toString(expected_triangles);
   }
 
@@ -297,6 +297,17 @@ kimera_pgmo::test::BlockConfig block1_v2{
     {{{{0.5, 0.5, 0.5}, {0.5, 0.75, 0.75}, {0.5, 0.75, 0.5}}},
      {{{0.0, 0.0, 0.0}, {0.0, 0.5, 0.5}, {0.0, 0.0, 0.5}}}}};
 
+// contains the same vertices as block1_v1 but with a face that has the boundary vertex
+// with b2v2
+kimera_pgmo::test::BlockConfig block1_v3{
+    "block1_v3",
+    {0, 0, 0},
+    {
+        {{{0.5, 0.5, 0.5}, {0.5, 0.75, 0.75}, {0.5, 0.75, 0.5}}},
+        {{{0.0, 0.0, 0.0}, {0.0, 0.5, 0.5}, {0.0, 0.0, 0.5}}},
+        {{{0.1, 0.2, 0.3}, {0.2, 0.3, 0.4}, {0.0, 0.0, 0.5}}},
+    }};
+
 // contains no vertices or faces and should clear any faces
 kimera_pgmo::test::BlockConfig block2_empty{"block2_empty", {-1, 0, 0}, {}};
 
@@ -307,7 +318,7 @@ kimera_pgmo::test::BlockConfig block2_v1{
     {{{{-0.5, 0.5, 0.5}, {-0.5, 0.75, 0.75}, {-0.5, 0.75, 0.5}}},
      {{{0.0, 0.0, 0.0}, {0.0, 0.5, 0.5}, {0.0, 0.0, 0.5}}}}};
 
-// contains 2 faces, 1, unique and 1 partially shared with block1_v1 and block1_v2
+// contains 2 faces, 1 unique and 1 partially shared with block1_v1 and block1_v2
 kimera_pgmo::test::BlockConfig block2_v2{
     "block2_v2",
     {-1, 0, 0},
@@ -440,9 +451,27 @@ CompressionTestConfiguration test_configurations[] = {
         {{0, 1, 2}, {12, 13, 14}, {15, 16, 17}, {15, 16, 5}},  // all faces
         {12, 13, 14, 15, 16, 17}}},                            // b2v2 with 12 offset
       {{std::nullopt, 104s, {block2_empty}},
-       {{4, 1, 2},      // 2 shared vertices with b2 get archived this pass
+       {{3, 1, 3},      // Only b1 vertices not shared with b2 have been archived
         {{15, 16, 5}},  // partial face
         {}}}}},         // no remapping
+    {"BoundaryVertexRemapping",
+     1.0e-3,
+     {{{std::nullopt, 100s, {block1_v3}},
+       {{0, 0, 8},  // b1 (v3)
+        {{0, 1, 2}, {3, 4, 5}, {6, 7, 5}},
+        {0, 1, 2, 3, 4, 5, 6, 7, 5}}},
+      {{std::nullopt, 102s, {block2_v2}},
+       {{0, 0, 12},  // b2 (v2): 1 extra vertex
+        {{0, 1, 2}, {12, 13, 5}, {6, 7, 5}, {9, 10, 11}, {12, 13, 14}},
+        {9, 10, 11, 12, 13, 14}}},
+      {{101s, 103s, {block1_empty, block2_v2}},
+       {{0, 0, 12},  // b1 archived + b2v2
+        {{0, 1, 2}, {18, 19, 5}, {6, 7, 5}, {15, 16, 17}, {18, 19, 20}},
+        {15, 16, 17, 18, 19, 20}}},
+      {{std::nullopt, 104s, {block2_empty}},
+       {{3, 1, 5},  // Only b1 vertices not shared with b2 have been archived
+        {{18, 19, 5}, {6, 7, 5}},
+        {}}}}},
     {"RepeatedTimestamp",
      1.0e-3,
      {{{std::nullopt, 100s, {block1_v1}},

--- a/kimera_pgmo/test/test_delta_compression.cpp
+++ b/kimera_pgmo/test/test_delta_compression.cpp
@@ -348,140 +348,152 @@ kimera_pgmo::test::BlockConfig block2_v2{
 CompressionTestConfiguration test_configurations[] = {
     {"SingleBlockClearing",
      1.0e-3,
-     {{{std::nullopt, 100s, {block1_v1}},
-       {{0, 0, 6},                      // b1 vertices
-        {{0, 1, 2}, {6, 7, 8}},         // b1.f2 redundant
-        {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // b1.f2 vertices redundant
-      {{std::nullopt, 101s, {block1_empty}}, {{0, 0, 0}, {}, {}}}}},
+     {
+         {{std::nullopt, 100s, {block1_v1}},
+          {{0, 0, 6},                      // b1 vertices
+           {{0, 1, 2}, {6, 7, 8}},         // b1.f2 redundant
+           {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // b1.f2 vertices redundant
+         {{std::nullopt, 101s, {block1_empty}}, {{0, 0, 0}, {}, {}}},
+     }},
     {"SingleBlockPrune",
      1.0e-3,
-     {{{std::nullopt, 100s, {block1_v1}},
-       {{0, 0, 6},                      // b1 vertices
-        {{0, 1, 2}, {6, 7, 8}},         // b1.f2 redundant
-        {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // b1.f2 vertices redundant
-      {{101s, 102s, {block1_empty}},
-       {{0, 0, 6},               // b1 vertices archived
-        {{0, 1, 2}, {6, 7, 8}},  // b1 non-duplicate faces
-        {}}},                    // empty block, no remmaping
-      {{std::nullopt, 103s, {block1_v1}},
-       {{6, 2, 6},                               // b1 archived plus b1 vertices
-        {{9, 10, 11}, {15, 16, 17}},             // b1 faces offset by 9
-        {9, 10, 11, 9, 10, 11, 15, 16, 17}}}}},  // b1 vertices offset by 9
+     {
+         {{std::nullopt, 100s, {block1_v1}},
+          {{0, 0, 6},                      // b1 vertices
+           {{0, 1, 2}, {6, 7, 8}},         // b1.f2 redundant
+           {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // b1.f2 vertices redundant
+         {{101s, 102s, {block1_empty}},
+          {{0, 0, 6},               // b1 vertices archived
+           {{0, 1, 2}, {6, 7, 8}},  // b1 non-duplicate faces
+           {}}},                    // empty block, no remmaping
+         {{std::nullopt, 103s, {block1_v1}},
+          {{6, 2, 6},                             // b1 archived plus b1 vertices
+           {{9, 10, 11}, {15, 16, 17}},           // b1 faces offset by 9
+           {9, 10, 11, 9, 10, 11, 15, 16, 17}}},  // b1 vertices offset by 9
+     }},
     {"MultiBlockClearing",
      1.0e-3,
-     {{{std::nullopt, 100s, {block1_v1, block2_v1}},
-       {{0, 0, 9},                                          // b1 and b2 vertices
-        {{0, 1, 2}, {6, 7, 8}, {9, 10, 11}},                // b1.f2 and b2.f2 redundant
-        {0, 1, 2, 0, 1, 2, 6, 7, 8, 9, 10, 11, 6, 7, 8}}},  // no offset
-      {{std::nullopt, 101s, {block1_empty, block2_v1}},
-       {{0, 0, 6},                     // b1 cleared: b2 vertices
-        {{15, 16, 17}, {18, 19, 20}},  // b2 faces
-        {15, 16, 17, 18, 19, 20}}},    // b2 remaps to itself (offset 15)
-      {{std::nullopt, 102s, {block1_v1, block2_v1}},
-       {{0, 0, 9},                                   // b1 added again: 9 vertices
-        {{21, 22, 23}, {27, 28, 29}, {30, 31, 32}},  // b1.f2 and b2.f2 redundant
-        {21, 22, 23, 21, 22, 23, 27, 28, 29, 30, 31, 32, 27, 28, 29}}},  // offset 21
-      {{std::nullopt, 103s, {block1_v1, block2_empty}},
-       {{0, 0, 6},                                 // b2 cleared
-        {{36, 37, 38}, {42, 43, 44}},              // both b1 faces
-        {36, 37, 38, 36, 37, 38, 42, 43, 44}}}}},  // offset by 36
+     {
+         {{std::nullopt, 100s, {block1_v1, block2_v1}},
+          {{0, 0, 9},                            // b1 and b2 vertices
+           {{0, 1, 2}, {6, 7, 8}, {9, 10, 11}},  // b1.f2 and b2.f2 redundant
+           {0, 1, 2, 0, 1, 2, 6, 7, 8, 9, 10, 11, 6, 7, 8}}},  // no offset
+         {{std::nullopt, 101s, {block1_empty, block2_v1}},
+          {{0, 0, 6},                     // b1 cleared: b2 vertices
+           {{15, 16, 17}, {18, 19, 20}},  // b2 faces
+           {15, 16, 17, 18, 19, 20}}},    // b2 remaps to itself (offset 15)
+         {{std::nullopt, 102s, {block1_v1, block2_v1}},
+          {{0, 0, 9},                                   // b1 added again: 9 vertices
+           {{21, 22, 23}, {27, 28, 29}, {30, 31, 32}},  // b1.f2 and b2.f2 redundant
+           {21, 22, 23, 21, 22, 23, 27, 28, 29, 30, 31, 32, 27, 28, 29}}},  // offset 21
+         {{std::nullopt, 103s, {block1_v1, block2_empty}},
+          {{0, 0, 6},                               // b2 cleared
+           {{36, 37, 38}, {42, 43, 44}},            // both b1 faces
+           {36, 37, 38, 36, 37, 38, 42, 43, 44}}},  // offset by 36
+     }},
     {"MultiBlockPrune",
      1.0e-3,
-     {{{std::nullopt, 100s, {block1_v1}},
-       {{0, 0, 6},                      // b1: 6 vertices
-        {{0, 1, 2}, {6, 7, 8}},         // b1: 2 faces
-        {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // normal remapping for b1
-      {{std::nullopt, 102s, {block2_v1}},
-       {{0, 0, 9},                               // b2: 9 vertices
-        {{0, 1, 2}, {9, 10, 11}, {12, 13, 14}},  // b1 + b2 faces (no b1 offset)
-        {9, 10, 11, 12, 13, 14}}},  // b2 vertices override previous clusters
-      {{101s, 103s, {block1_empty, block2_empty}},
-       {{0, 0, 6},                  // b1 archived
-        {{0, 1, 2}, {12, 13, 14}},  // b1 archived faces
-        {}}},                       // no remapping for empty input
-      {{std::nullopt, 104s, {block1_v1}},
-       {{6, 2, 6},                               // b1 added again
-        {{15, 16, 17}, {21, 22, 23}},            // b1 faces
-        {15, 16, 17, 15, 16, 17, 21, 22, 23}}},  // offset 15
-      {{std::nullopt, 105s, {block1_v1}},
-       {{6, 2, 6},                                 // b1 stays added
-        {{24, 25, 26}, {30, 31, 32}},              // faces indices overriden
-        {24, 25, 26, 24, 25, 26, 30, 31, 32}}}}},  // offset 24
+     {
+         {{std::nullopt, 100s, {block1_v1}},
+          {{0, 0, 6},                      // b1: 6 vertices
+           {{0, 1, 2}, {6, 7, 8}},         // b1: 2 faces
+           {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // normal remapping for b1
+         {{std::nullopt, 102s, {block2_v1}},
+          {{0, 0, 9},                               // b2: 9 vertices
+           {{0, 1, 2}, {9, 10, 11}, {12, 13, 14}},  // b1 + b2 faces (no b1 offset)
+           {9, 10, 11, 12, 13, 14}}},  // b2 vertices override previous clusters
+         {{101s, 103s, {block1_empty, block2_empty}},
+          {{0, 0, 6},                  // b1 archived
+           {{0, 1, 2}, {12, 13, 14}},  // b1 archived faces
+           {}}},                       // no remapping for empty input
+         {{std::nullopt, 104s, {block1_v1}},
+          {{6, 2, 6},                               // b1 added again
+           {{15, 16, 17}, {21, 22, 23}},            // b1 faces
+           {15, 16, 17, 15, 16, 17, 21, 22, 23}}},  // offset 15
+         {{std::nullopt, 105s, {block1_v1}},
+          {{6, 2, 6},                               // b1 stays added
+           {{24, 25, 26}, {30, 31, 32}},            // faces indices overriden
+           {24, 25, 26, 24, 25, 26, 30, 31, 32}}},  // offset 24
+     }},
     {"MultiBlockPartialUpdates",
      1.0e-3,
-     {{{std::nullopt, 100s, {block1_v1}},
-       {{0, 0, 6},                      // b1 vertices
-        {{0, 1, 2}, {6, 7, 8}},         // b1.f2 duplicate
-        {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // no offset
-      {{std::nullopt, 102s, {block2_v1}},
-       {{0, 0, 9},                               // b1 + b2 vertices
-        {{0, 1, 2}, {9, 10, 11}, {12, 13, 14}},  // b1.f2 and b2.f2 duplicate
-        {9, 10, 11, 12, 13, 14}}},               // b2 with offset 9
-      {{101s, 103s, {block1_empty, block2_v1}},
-       {{0, 0, 9},                                              // b1 archive
-        {{0, 1, 2}, {15, 16, 17}, {18, 19, 20}, {18, 19, 20}},  // b2.f2 duplicate
-                                                                // with archived
-                                                                // b1.f2
-        {15, 16, 17, 18, 19, 20}}},                             // b2 with offset 15
-      {{std::nullopt, 104s, {block2_v1}},
-       {{3, 1, 6},                                   // b2 re-added
-        {{21, 22, 23}, {24, 25, 26}, {24, 25, 26}},  // b2.f2 duplicate with b1.f2
-        {21, 22, 23, 24, 25, 26}}},                  // b2 with offset 21
-      {{std::nullopt, 105s, {block1_v1, block2_v1}},
-       {{3, 1, 9},                                                 // b1+b2
-        {{27, 28, 29}, {33, 34, 35}, {36, 37, 38}, {33, 34, 35}},  // b2.f2 + b1.f2
-        {27, 28, 29, 27, 28, 29, 33, 34, 35, 36, 37, 38, 33, 34, 35}}},  // offset 27
-                                                                         // b1 + b2
-      {{std::nullopt, 106s, {block1_empty, block2_empty}},
-       {{3, 1, 3},       // back to empty
-        {{33, 34, 35}},  // partial archive finalized
-        {}}}}},          // no remapping
+     {
+         {{std::nullopt, 100s, {block1_v1}},
+          {{0, 0, 6},                      // b1 vertices
+           {{0, 1, 2}, {6, 7, 8}},         // b1.f2 duplicate
+           {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // no offset
+         {{std::nullopt, 102s, {block2_v1}},
+          {{0, 0, 9},                               // b1 + b2 vertices
+           {{0, 1, 2}, {9, 10, 11}, {12, 13, 14}},  // b1.f2 and b2.f2 duplicate
+           {9, 10, 11, 12, 13, 14}}},               // b2 with offset 9
+         {{101s, 103s, {block1_empty, block2_v1}},
+          {{0, 0, 9},                                              // b1 archive
+           {{0, 1, 2}, {15, 16, 17}, {18, 19, 20}, {18, 19, 20}},  // b2.f2 duplicate
+                                                                   // with archived
+                                                                   // b1.f2
+           {15, 16, 17, 18, 19, 20}}},                             // b2 with offset 15
+         {{std::nullopt, 104s, {block2_v1}},
+          {{3, 1, 6},                                   // b2 re-added
+           {{21, 22, 23}, {24, 25, 26}, {24, 25, 26}},  // b2.f2 duplicate with b1.f2
+           {21, 22, 23, 24, 25, 26}}},                  // b2 with offset 21
+         {{std::nullopt, 105s, {block1_v1, block2_v1}},
+          {{3, 1, 9},                                                 // b1+b2
+           {{27, 28, 29}, {33, 34, 35}, {36, 37, 38}, {33, 34, 35}},  // b2.f2 + b1.f2
+           {27, 28, 29, 27, 28, 29, 33, 34, 35, 36, 37, 38, 33, 34, 35}}},  // offset 27
+         {{std::nullopt, 106s, {block1_empty, block2_empty}},
+          {{3, 1, 3},       // back to empty
+           {{33, 34, 35}},  // partial archive finalized
+           {}}},            // no remapping
+     }},
     {"MultiBlockPartialArchive",
      1.0e-3,
-     {{{std::nullopt, 100s, {block1_v2}},
-       {{0, 0, 6},               // b1 (v2)
-        {{0, 1, 2}, {3, 4, 5}},  // both faces
-        {0, 1, 2, 3, 4, 5}}},
-      {{std::nullopt, 102s, {block2_v2}},
-       {{0, 0, 10},                                       // b2 (v2): 1 extra vertex
-        {{0, 1, 2}, {9, 10, 5}, {6, 7, 8}, {9, 10, 11}},  // all faces, b2v2 overrides
-        {6, 7, 8, 9, 10, 11}}},                           // b2 only remapping
-      {{101s, 103s, {block1_empty, block2_v2}},
-       {{0, 0, 10},                                            // b1 archived + b2v2
-        {{0, 1, 2}, {12, 13, 14}, {15, 16, 17}, {15, 16, 5}},  // all faces
-        {12, 13, 14, 15, 16, 17}}},                            // b2v2 with 12 offset
-      {{std::nullopt, 104s, {block2_empty}},
-       {{3, 1, 3},      // Only b1 vertices not shared with b2 have been archived
-        {{15, 16, 5}},  // partial face
-        {}}}}},         // no remapping
+     {
+         {{std::nullopt, 100s, {block1_v2}},
+          {{0, 0, 6},               // b1 (v2)
+           {{0, 1, 2}, {3, 4, 5}},  // both faces
+           {0, 1, 2, 3, 4, 5}}},
+         {{std::nullopt, 102s, {block2_v2}},
+          {{0, 0, 10},                                       // b2 (v2): 1 extra vertex
+           {{0, 1, 2}, {9, 10, 5}, {6, 7, 8}, {9, 10, 11}},  // all faces, b2v2
+                                                             // overrides
+           {6, 7, 8, 9, 10, 11}}},                           // b2 only remapping
+         {{101s, 103s, {block1_empty, block2_v2}},
+          {{0, 0, 10},                                            // b1 archived + b2v2
+           {{0, 1, 2}, {12, 13, 14}, {15, 16, 17}, {15, 16, 5}},  // all faces
+           {12, 13, 14, 15, 16, 17}}},                            // b2v2 with 12 offset
+         {{std::nullopt, 104s, {block2_empty}},
+          {{3, 1, 3},      // Only b1 vertices not shared with b2 have been archived
+           {{15, 16, 5}},  // partial face
+           {}}},           // no remapping
+     }},
     {"BoundaryVertexRemapping",
      1.0e-3,
-     {{{std::nullopt, 100s, {block1_v3}},
-       {{0, 0, 8},  // b1 (v3)
-        {{0, 1, 2}, {3, 4, 5}, {6, 7, 5}},
-        {0, 1, 2, 3, 4, 5, 6, 7, 5}}},
-      {{std::nullopt, 102s, {block2_v2}},
-       {{0, 0, 12},  // b2 (v2): 1 extra vertex
-        {{0, 1, 2}, {12, 13, 5}, {6, 7, 5}, {9, 10, 11}, {12, 13, 14}},
-        {9, 10, 11, 12, 13, 14}}},
-      {{101s, 103s, {block1_empty, block2_v2}},
-       {{0, 0, 12},  // b1 archived + b2v2
-        {{0, 1, 2}, {18, 19, 5}, {6, 7, 5}, {15, 16, 17}, {18, 19, 20}},
-        {15, 16, 17, 18, 19, 20}}},
-      {{std::nullopt, 104s, {block2_empty}},
-       {{3, 1, 5},  // Only b1 vertices not shared with b2 have been archived
-        {{18, 19, 5}, {6, 7, 5}},
-        {}}}}},
+     {
+         {{std::nullopt, 100s, {block1_v3}},
+          {{0, 0, 8}, {{0, 1, 2}, {3, 4, 5}, {6, 7, 5}}, {0, 1, 2, 3, 4, 5, 6, 7, 5}}},
+         {{std::nullopt, 102s, {block2_v2}},
+          {{0, 0, 12},
+           {{0, 1, 2}, {12, 13, 5}, {6, 7, 5}, {9, 10, 11}, {12, 13, 14}},
+           {9, 10, 11, 12, 13, 14}}},
+         {{101s, 103s, {block1_empty, block2_v2}},
+          {{0, 0, 12},
+           {{0, 1, 2}, {18, 19, 5}, {6, 7, 5}, {15, 16, 17}, {18, 19, 20}},
+           {15, 16, 17, 18, 19, 20}}},
+         {{std::nullopt, 104s, {block2_empty}}, {{3, 2, 5}, {{18, 19, 5}}, {}}},
+         {{std::nullopt, 105s, {block2_empty}}, {{3, 2, 5}, {{18, 19, 5}}, {}}},
+     }},
     {"RepeatedTimestamp",
      1.0e-3,
-     {{{std::nullopt, 100s, {block1_v1}},
-       {{0, 0, 6},                      // b1 vertices
-        {{0, 1, 2}, {6, 7, 8}},         // b1.f2 redundant
-        {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // no offset
-      {{std::nullopt, 100s, {block2_v1}},
-       {{0, 0, 9},                               // b2 vertices added
-        {{0, 1, 2}, {9, 10, 11}, {12, 13, 14}},  // b1.f1, b1.f3, b2.f1
-        {9, 10, 11, 12, 13, 14}}}}},             // b2 remaps to itself (offset 9)
+     {
+         {{std::nullopt, 100s, {block1_v1}},
+          {{0, 0, 6},                      // b1 vertices
+           {{0, 1, 2}, {6, 7, 8}},         // b1.f2 redundant
+           {0, 1, 2, 0, 1, 2, 6, 7, 8}}},  // no offset
+         {{std::nullopt, 100s, {block2_v1}},
+          {{0, 0, 9},                               // b2 vertices added
+           {{0, 1, 2}, {9, 10, 11}, {12, 13, 14}},  // b1.f1, b1.f3, b2.f1
+           {9, 10, 11, 12, 13, 14}}},               // b2 remaps to itself (offset 9)
+     }},
 };
 
 }  // namespace


### PR DESCRIPTION
Changes to the delta compression that we talked about (a delta will only archive a vertex only if all the faces that point to that vertex only point to other vertices that have been archived), which means that you can "rebase" a delta on a mesh where previously archived vertices have been deleted / changed without any issues.

I'm pretty sure the implementation is correct / I caught a corner case when testing in Hydra that is captured in the new unit test, but let me know if you see any weird issues when running with this. I'm also going to check how expensive the new archival process is, I think it should be fine but we'll see

