### PR TITLE
add deformation-graph rebuild support

### DIFF
--- a/kimera_pgmo/include/kimera_pgmo/deformation_graph.h
+++ b/kimera_pgmo/include/kimera_pgmo/deformation_graph.h
@@ -598,6 +598,11 @@ class DeformationGraph {
     vertex_stamps_.clear();
   }
 
+  /*! \brief Clear only mesh vertices and their associated factors
+   * Preserves robot poses and pose-only factors
+   */
+  void clearMeshNodesOnly();
+
   /*! \brief Clear all temporary values, factors, and related structures
    */
   inline void clearFactors() {

--- a/kimera_pgmo/include/kimera_pgmo/deformation_graph.h
+++ b/kimera_pgmo/include/kimera_pgmo/deformation_graph.h
@@ -603,6 +603,10 @@ class DeformationGraph {
    */
   void clearMeshNodesOnly();
 
+  /*! \brief Clear the last mesh interpolation cache
+   */
+  void clearMeshCache() { last_calculated_vertices_.clear(); }
+
   /*! \brief Clear all temporary values, factors, and related structures
    */
   inline void clearFactors() {

--- a/kimera_pgmo/include/kimera_pgmo/utils/common_functions.h
+++ b/kimera_pgmo/include/kimera_pgmo/utils/common_functions.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Symbol.h>
 #include <pcl/PolygonMesh.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -79,6 +80,26 @@ inline char GetVertexPrefix(size_t robot_id) {
     return '\0';
   }
   return robot_id_to_vertex_prefix.at(robot_id);
+}
+
+/*! \brief Get all mesh vertex prefixes used in the system
+ *  - outputs set of all mesh vertex prefixes
+ */
+inline std::set<char> GetMeshVertexPrefixes() {
+  std::set<char> prefixes;
+  for (const auto& [robot_id, prefix] : robot_id_to_vertex_prefix) {
+    prefixes.insert(prefix);
+  }
+  return prefixes;
+}
+
+/*! \brief Check if a GTSAM key represents a mesh vertex
+ *  - key: GTSAM key to check
+ *  - outputs true if key is a mesh vertex, false otherwise
+ */
+inline bool IsMeshVertex(gtsam::Key key) {
+  static const auto mesh_prefixes = GetMeshVertexPrefixes();
+  return mesh_prefixes.count(gtsam::Symbol(key).chr()) > 0;
 }
 
 /*! \brief Converts a pcl point to gtsam point3

--- a/kimera_pgmo/include/kimera_pgmo/utils/common_functions.h
+++ b/kimera_pgmo/include/kimera_pgmo/utils/common_functions.h
@@ -82,24 +82,12 @@ inline char GetVertexPrefix(size_t robot_id) {
   return robot_id_to_vertex_prefix.at(robot_id);
 }
 
-/*! \brief Get all mesh vertex prefixes used in the system
- *  - outputs set of all mesh vertex prefixes
- */
-inline std::set<char> GetMeshVertexPrefixes() {
-  std::set<char> prefixes;
-  for (const auto& [robot_id, prefix] : robot_id_to_vertex_prefix) {
-    prefixes.insert(prefix);
-  }
-  return prefixes;
-}
-
 /*! \brief Check if a GTSAM key represents a mesh vertex
  *  - key: GTSAM key to check
  *  - outputs true if key is a mesh vertex, false otherwise
  */
 inline bool IsMeshVertex(gtsam::Key key) {
-  static const auto mesh_prefixes = GetMeshVertexPrefixes();
-  return mesh_prefixes.count(gtsam::Symbol(key).chr()) > 0;
+  return vertex_prefix_to_id.count(gtsam::Symbol(key).chr()) > 0;
 }
 
 /*! \brief Converts a pcl point to gtsam point3

--- a/kimera_pgmo/src/deformation_graph.cpp
+++ b/kimera_pgmo/src/deformation_graph.cpp
@@ -1034,35 +1034,22 @@ void DeformationGraph::clearMeshNodesOnly() {
   vertex_positions_.clear();
   vertex_stamps_.clear();
   adjacency_map_.clear();
-  last_calculated_vertices_.clear();
 
   // Remove mesh vertices from values_
-  gtsam::Values new_values;
+  auto new_values = std::make_shared<gtsam::Values>();
   for (const auto& key_value : *values_) {
     gtsam::Key key = key_value.key;
     if (!IsMeshVertex(key)) {
       // Keep non-mesh vertices (robot poses)
-      new_values.insert(key, values_->at(key));
+      new_values->insert(key, values_->at(key));
     }
   }
-  values_ = std::make_shared<gtsam::Values>(new_values);
-
-  // Remove mesh vertices from temp_values_
-  gtsam::Values new_temp_values;
-  for (const auto& key_value : *temp_values_) {
-    gtsam::Key key = key_value.key;
-    if (!IsMeshVertex(key)) {
-      // Keep non-mesh vertices
-      new_temp_values.insert(key, temp_values_->at(key));
-    }
-  }
-  temp_values_ = std::make_shared<gtsam::Values>(new_temp_values);
+  values_ = new_values;
 
   // Remove factors involving mesh vertices
-  gtsam::NonlinearFactorGraph new_factors;
-  for (size_t i = 0; i < nfg_->size(); ++i) {
-    auto factor = (*nfg_)[i];
-    if (!factor) continue;
+  auto new_factors = std::make_shared<gtsam::NonlinearFactorGraph>();
+  for (const auto& factor : *nfg_) {
+    if (!factor) { continue; }
 
     bool involves_mesh = false;
     for (const auto& key : factor->keys()) {
@@ -1074,16 +1061,16 @@ void DeformationGraph::clearMeshNodesOnly() {
 
     if (!involves_mesh) {
       // Keep factors that don't involve mesh vertices
-      new_factors.add(factor);
+      new_factors->add(factor);
     }
   }
-  nfg_ = std::make_shared<gtsam::NonlinearFactorGraph>(new_factors);
+  nfg_ = new_factors;
 
   // Remove temp factors involving mesh vertices
   gtsam::NonlinearFactorGraph new_temp_factors;
   for (size_t i = 0; i < temp_nfg_->size(); ++i) {
     auto factor = (*temp_nfg_)[i];
-    if (!factor) continue;
+    if (!factor) { continue; }
 
     bool involves_mesh = false;
     for (const auto& key : factor->keys()) {

--- a/kimera_pgmo/src/deformation_graph.cpp
+++ b/kimera_pgmo/src/deformation_graph.cpp
@@ -1029,4 +1029,74 @@ void DeformationGraph::updateInlierWeights(const std::vector<double>& weights) {
 void DeformationGraph::updateTempInlierWeights(const std::vector<double>& weights) {
   *temp_inlier_weights_ = weights;
 }
+
+void DeformationGraph::clearMeshNodesOnly() {
+  vertex_positions_.clear();
+  vertex_stamps_.clear();
+  adjacency_map_.clear();
+  last_calculated_vertices_.clear();
+
+  // Remove mesh vertices from values_
+  gtsam::Values new_values;
+  for (const auto& key_value : *values_) {
+    gtsam::Key key = key_value.key;
+    if (!IsMeshVertex(key)) {
+      // Keep non-mesh vertices (robot poses)
+      new_values.insert(key, values_->at(key));
+    }
+  }
+  values_ = std::make_shared<gtsam::Values>(new_values);
+
+  // Remove mesh vertices from temp_values_
+  gtsam::Values new_temp_values;
+  for (const auto& key_value : *temp_values_) {
+    gtsam::Key key = key_value.key;
+    if (!IsMeshVertex(key)) {
+      // Keep non-mesh vertices
+      new_temp_values.insert(key, temp_values_->at(key));
+    }
+  }
+  temp_values_ = std::make_shared<gtsam::Values>(new_temp_values);
+
+  // Remove factors involving mesh vertices
+  gtsam::NonlinearFactorGraph new_factors;
+  for (size_t i = 0; i < nfg_->size(); ++i) {
+    auto factor = (*nfg_)[i];
+    if (!factor) continue;
+
+    bool involves_mesh = false;
+    for (const auto& key : factor->keys()) {
+      if (IsMeshVertex(key)) {
+        involves_mesh = true;
+        break;
+      }
+    }
+
+    if (!involves_mesh) {
+      // Keep factors that don't involve mesh vertices
+      new_factors.add(factor);
+    }
+  }
+  nfg_ = std::make_shared<gtsam::NonlinearFactorGraph>(new_factors);
+
+  // Remove temp factors involving mesh vertices
+  gtsam::NonlinearFactorGraph new_temp_factors;
+  for (size_t i = 0; i < temp_nfg_->size(); ++i) {
+    auto factor = (*temp_nfg_)[i];
+    if (!factor) continue;
+
+    bool involves_mesh = false;
+    for (const auto& key : factor->keys()) {
+      if (IsMeshVertex(key)) {
+        involves_mesh = true;
+        break;
+      }
+    }
+
+    if (!involves_mesh) {
+      new_temp_factors.add(factor);
+    }
+  }
+  temp_nfg_ = std::make_shared<gtsam::NonlinearFactorGraph>(new_temp_factors);
+}
 }  // namespace kimera_pgmo

--- a/kimera_pgmo_ros/src/visualization_functions.cpp
+++ b/kimera_pgmo_ros/src/visualization_functions.cpp
@@ -55,8 +55,9 @@ void fillDeformationGraphMarkers(const DeformationGraph& graph,
 
     if (!front_is_pose_vertex && !back_is_pose_vertex) {
       // mesh-to-mesh
-      if (!graph_values->exists(front) || !graph_values->exists(back))
+      if (!graph_values->exists(front) || !graph_values->exists(back)) {
         continue;
+      }
 
       auto& p_front = mesh_mesh_viz.points.emplace_back();
       tf2::convert(graph_values->at<gtsam::Pose3>(front).translation(), p_front);
@@ -70,8 +71,9 @@ void fillDeformationGraphMarkers(const DeformationGraph& graph,
       mesh_mesh_viz.colors.push_back(color);
     } else {
       // pose-to-mesh
-      if (!graph_values->exists(front) || !graph_values->exists(back))
+      if (!graph_values->exists(front) || !graph_values->exists(back)) {
         continue;
+      }
 
       auto& p_front = pose_mesh_viz.points.emplace_back();
       tf2::convert(graph_values->at<gtsam::Pose3>(front).translation(), p_front);

--- a/kimera_pgmo_ros/src/visualization_functions.cpp
+++ b/kimera_pgmo_ros/src/visualization_functions.cpp
@@ -55,6 +55,9 @@ void fillDeformationGraphMarkers(const DeformationGraph& graph,
 
     if (!front_is_pose_vertex && !back_is_pose_vertex) {
       // mesh-to-mesh
+      if (!graph_values->exists(front) || !graph_values->exists(back))
+        continue;
+
       auto& p_front = mesh_mesh_viz.points.emplace_back();
       tf2::convert(graph_values->at<gtsam::Pose3>(front).translation(), p_front);
       auto& p_back = mesh_mesh_viz.points.emplace_back();
@@ -67,6 +70,9 @@ void fillDeformationGraphMarkers(const DeformationGraph& graph,
       mesh_mesh_viz.colors.push_back(color);
     } else {
       // pose-to-mesh
+      if (!graph_values->exists(front) || !graph_values->exists(back))
+        continue;
+
       auto& p_front = pose_mesh_viz.points.emplace_back();
       tf2::convert(graph_values->at<gtsam::Pose3>(front).translation(), p_front);
       auto& p_back = pose_mesh_viz.points.emplace_back();


### PR DESCRIPTION
Lets us rebuild deformation graphs from an arbitrary mesh. Mostly we need to be able to clear the mesh nodes only but keep pose-related factors.

Not related to #27, should go directly to develop after that is merged.