### PR TITLE
fix indexing bug and lc viarance setting preventing correct lc rejection

### DIFF
--- a/kimera_pgmo/src/deformation_graph.cpp
+++ b/kimera_pgmo/src/deformation_graph.cpp
@@ -253,8 +253,7 @@ void DeformationGraph::addDeformationEdge(const gtsam::Key& from_key,
                                           double variance,
                                           bool temp,
                                           bool known_inlier) {
-  // Define noise. Hardcoded for now
-  static const gtsam::SharedNoiseModel& noise =
+  const gtsam::SharedNoiseModel noise =
       gtsam::noiseModel::Isotropic::Variance(3, variance);
   // Create deformation edge factor
   const DeformationEdgeFactor new_edge(from_key, to_key, from_pose, to_point, noise);
@@ -279,8 +278,7 @@ void DeformationGraph::addDeformationEdge(const gtsam::Key& from_key,
                                           double variance,
                                           bool temp,
                                           bool known_inlier) {
-  // Define noise. Hardcoded for now
-  static const gtsam::SharedNoiseModel& noise =
+  const gtsam::SharedNoiseModel noise =
       gtsam::noiseModel::Isotropic::Variance(3, variance);
   // Create deformation edge factor
   const DeformationEdgeFactor new_edge(from_key, to_key, measurement, noise);
@@ -356,6 +354,15 @@ bool DeformationGraph::checkNewBetween(const gtsam::Key& key_from,
   const size_t& from_idx = gtsam::Symbol(key_from).index();
   const size_t& to_idx = gtsam::Symbol(key_to).index();
 
+  // Check if prefixes exist in pg_initial_poses_
+  if (!pg_initial_poses_.count(from_prefix)) {
+    return false;
+  }
+
+  if (!pg_initial_poses_.count(to_prefix)) {
+    return false;
+  }
+
   if (from_idx >= pg_initial_poses_.at(from_prefix).size()) {
     SPARK_LOG(ERROR)
         << "DeformationGraph: when adding new between from key should already exist.";
@@ -394,7 +401,7 @@ void DeformationGraph::addNewBetween(const gtsam::Key& key_from,
   gtsam::Vector6 variances;
   variances.head<3>().setConstant(1e-02 * variance);
   variances.tail<3>().setConstant(variance);
-  static const gtsam::SharedNoiseModel& noise =
+  const gtsam::SharedNoiseModel noise =
       gtsam::noiseModel::Diagonal::Variances(variances);
   if (temp) {
     if (known_inlier) {

--- a/kimera_pgmo/src/kimera_pgmo_interface.cpp
+++ b/kimera_pgmo/src/kimera_pgmo_interface.cpp
@@ -518,11 +518,12 @@ OptimizeStats KimeraPgmoInterface::optimize() {
   auto inlier_weights = pgo_->getInlierWeights();
   auto temp_inlier_weights = pgo_->getTempInlierWeights();
 
-  size_t index = 0;
   OptimizeStats stats;
   stats.total_factors = factors.size() + temp_factors.size();
   stats.total_values = estimates.size() + temp_estimates.size();
-  for (const auto& factor : factors) {
+
+  for (size_t factor_idx = 0; factor_idx < factors.size(); ++factor_idx) {
+    const auto& factor = factors[factor_idx];
     const auto derived = dynamic_cast<const BetweenFactorT*>(factor.get());
     if (!derived) {
       continue;
@@ -538,11 +539,10 @@ OptimizeStats KimeraPgmoInterface::optimize() {
 
     bool interrobot = k1.chr() != k2.chr();
     bool inlier = true;
-    if (inlier_weights.size() < index && inlier_weights[index] < 0.5) {
+    if (factor_idx < inlier_weights.size() && inlier_weights[factor_idx] < 0.5) {
       inlier = false;
     }
 
-    ++index;
     stats.total_loop_closures += 1;
     stats.inlier_loop_closures += (inlier ? 1 : 0);
     if (interrobot) {


### PR DESCRIPTION
* deformation_graph.cpp was using static noise variables - so they are set only once and then used throughout the pose graph. This causes issues for instance if you want to use a different variance on loop closure edges
* fix indexing in kimera_pgmo_interface.cpp - loop closure outlier indexing was being increment per-loop closure, but inlier status is a per-factor value. Changed to index by factors